### PR TITLE
Check for existing allOf block before creating it.

### DIFF
--- a/schema205/json_translate.py
+++ b/schema205/json_translate.py
@@ -128,10 +128,10 @@ class DataGroup:
         '''
         Construct paired if-then json entries for conditional requirements.
 
-        :param target_list_to_append:   List of dictionaries, modified in-situ with an if key and
-                                        an associated then key
+        :param conditionals_list:
+        :param dependencies_list:
         :param requirement_str:         Raw requirement string using A205 syntax
-        :param requirement:             This item's presence is dependent on the above condition
+        :param requirement:             requirement is present if requirement_str indicates it
         '''
         separator = r'\sand\s'
         collector = 'allOf'
@@ -206,7 +206,9 @@ class DataGroup:
                 if m:
                     types = [t.strip() for t in m.group(1).split(',')]
                     selection_key, selections = parent_dict['Constraints'].split('(')
-                    target_dict['allOf'] = list()
+                    if target_dict.get('allOf') == None:
+                        target_dict['allOf'] = list()
+                    #target_dict['allOf'] = list()
                     for s, t in zip(selections.split(','), types):
                         #c = c.strip()
                         target_dict['allOf'].append(dict())

--- a/schema205/json_translate.py
+++ b/schema205/json_translate.py
@@ -298,28 +298,30 @@ class DataGroup:
             minimum=None
             maximum=None
             for c in constraints:
-                try:
-                    numerical_value = re.findall(r'[+-]?[0-9]*\.?[0-9]+|[0-9]+', c)[0]
-                    if '>' in c:
-                        minimum = (float(numerical_value) if 'number' in target_dict['type'] else int(numerical_value))
-                        mn = 'exclusiveMinimum' if '=' not in c else 'minimum'
-                        target_dict[mn] = minimum
-                    elif '<' in c:
-                        maximum = (float(numerical_value) if 'number' in target_dict['type']  else int(numerical_value))
-                        mx = 'exclusiveMaximum' if '=' not in c else 'maximum'
-                        target_dict[mx] = maximum
-                    elif '%' in c:
-                        target_dict['multipleOf'] = int(numerical_value)
-                    # elif 'string' in target_dict['type']:  # String pattern match
-                    #     target_dict['pattern'] = c.replace('"','')  # TODO: Find better way to remove quotes.
-                except IndexError:
-                    # Constraint was non-numeric
-                    pass
-                except ValueError:
-                    pass
-                except KeyError:
-                    # 'type' not in dictionary
-                    pass
+                if 'string' in target_dict['type']:  # String pattern match
+                    target_dict['const'] = c.replace('"','')  # TODO: Find better way to remove quotes.
+                else:
+                    try:
+                        # TODO: any exotic constraint type with numerals in it, such as schmea=RS0001, will be processed here
+                        numerical_value = re.findall(r'[+-]?[0-9]*\.?[0-9]+|[0-9]+', c)[0]
+                        if '>' in c:
+                            minimum = (float(numerical_value) if 'number' in target_dict['type'] else int(numerical_value))
+                            mn = 'exclusiveMinimum' if '=' not in c else 'minimum'
+                            target_dict[mn] = minimum
+                        elif '<' in c:
+                            maximum = (float(numerical_value) if 'number' in target_dict['type']  else int(numerical_value))
+                            mx = 'exclusiveMaximum' if '=' not in c else 'maximum'
+                            target_dict[mx] = maximum
+                        elif '%' in c:
+                            target_dict['multipleOf'] = int(numerical_value)
+                    except IndexError:
+                        # Constraint was non-numeric
+                        pass
+                    except ValueError:
+                        pass
+                    except KeyError:
+                        # 'type' not in dictionary
+                        pass
 
 
 # -------------------------------------------------------------------------------------------------

--- a/schema205/json_translate.py
+++ b/schema205/json_translate.py
@@ -299,7 +299,7 @@ class DataGroup:
             maximum=None
             for c in constraints:
                 if 'string' in target_dict['type']:  # String pattern match
-                    target_dict['const'] = c.replace('"','')  # TODO: Find better way to remove quotes.
+                    target_dict['pattern'] = c.replace('"','')  # TODO: Find better way to remove quotes.
                 else:
                     try:
                         # TODO: any exotic constraint type with numerals in it, such as schmea=RS0001, will be processed here

--- a/schema205/schema.py
+++ b/schema205/schema.py
@@ -158,17 +158,20 @@ class A205Schema:
         if 'allOf' in parent_schema_node:
             # Alternate performance maps allowed. Make sure we get the right one
             for option in parent_schema_node['allOf']:
-                # allOf resolutions are 2-deep dictionaries; resolve twice
-                option = self.resolve(self.resolve(option)[lineage[-2]])
-                for var in grid_vars:
-                    option_grid_vars = self.resolve(option['grid_variables'])
-                    if var not in option_grid_vars:
-                        schema_node = None
+                # allOf resolutions are 2-deep dictionaries; resolve twice 
+                # first confirm that the option we're starting with is a performance map type
+                option = self.resolve(option).get(lineage[-2])
+                if option:
+                    option = self.resolve(option)
+                    for var in grid_vars:
+                        option_grid_vars = self.resolve(option['grid_variables'])
+                        if var not in option_grid_vars:
+                            schema_node = None
+                            break
+                        else:
+                            schema_node = option_grid_vars
+                    if schema_node:
                         break
-                    else:
-                        schema_node = option_grid_vars
-                if schema_node:
-                    break
         else:
             schema_node = self.get_schema_node(lineage)['properties']
         order = []

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -40,7 +40,7 @@ def test_get_schema_node():
 
     # Ambiguous node (without defined options, get_schema_node will return the first match it finds)
     schema = schema205.A205Schema(os.path.join(os.path.dirname(__file__),'..','build',"schema","RS0003.schema.json"))
-    node = schema.get_schema_node(['performance','performance_map','grid_variables'],[None, 0, None])
+    node = schema.get_schema_node(['performance','performance_map','grid_variables'],[None, 2, None])
     node2 = schema.get_schema_node(['performance','performance_map','grid_variables'],[None, 1, None])
     assert(node != node2)
 


### PR DESCRIPTION
Fix a latent bug where the selector constraint was overwriting an if-exists-then-required constraint. They should coexist nicely within an `allOf` block in json schema.